### PR TITLE
Output as selectors, rather than separate rules

### DIFF
--- a/source/src/family.scss
+++ b/source/src/family.scss
@@ -6,9 +6,13 @@
 /// @param {numeric} $num - id of the child
 /// @require $num - Cannot work with an empty argument
 @mixin first($num) {
+  @at-root{
+    %content { @content; }
+  }
+
   @for $i from 0 to $num + 1 {
     &:nth-child(#{$i}) {
-      @content
+      @extend %content;
     }
   }
 }


### PR DESCRIPTION
This is a proof of concept for flattening the output. I expect it should work with all other mixins as well, I simply added it for a single one to demonstrate the process and see if it's something you'd like.

_Previously_ the following:

``` scss
.outer {
  .thing {
    @include first(2) {
      opacity: 1;
    };
  }
}
```

Would output:

``` scss
.outer .thing:nth-child(0) {
  opacity: 1;
}
.outer .thing:nth-child(1) {
  opacity: 1;
}
```

Now, with this commit, the output is much more compact:

``` scss
.outer .thing:nth-child(0), .outer .thing:nth-child(1) {
  opacity: 1;
}
```

---

So basically, with this change, your README example outputs:

``` scss
ul li {
  background: blue;
}
ul li:nth-child(0), ul li:nth-child(1), ul li:nth-child(2) {
  background: red;
}
```

This makes a pretty big difference when the number is a bit larger. 
it is also _much_ easier to prototype changes on using browser developer tools.
