### PR TITLE
Feature/#61 extend each

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -233,7 +233,7 @@
         <header>
           <h3>n-between</h3>
         </header>
-        <pre><code id='n-between'><span class="param">@include</span> n-between(<span class="num" contenteditable id="n-between-a">3</span>,<span class="num" contenteditable id="n-between-b">3</span>,<span class="num" contenteditable id="n-between-c">13</span>)&#x000A;<span class="comment"> // This mixin uses 3 arguments, the first one is equal to N item,&#x000A; // the second is the starting item and the thirs the end item.  </span>&#x000A;</code></pre>
+        <pre><code id='n-between'><span class="param">@include</span> n-between(<span class="num" contenteditable id="n-between-a">3</span>,<span class="num" contenteditable id="n-between-b">3</span>,<span class="num" contenteditable id="n-between-c">13</span>)&#x000A;<span class="comment"> // This mixin uses 3 arguments, the first one is equal to N item,&#x000A; // the second is the starting item and the third the end item.  </span>&#x000A;</code></pre>
         <ul class='n-between'>
           <li>1</li>
           <li>2</li>
@@ -274,7 +274,7 @@
         <header>
           <h3>each</h3>
         </header>
-        <pre><code><span class="param"> @include</span> each(<span class="num" contenteditable id="each">3</span>)&#x000A;&#x000A;<span class="comment"> // Alias of each()</span>&#x000A;<span class="param"> @include</span> every(<span class="num" contenteditable id="each">3</span>)&#x000A;</code></pre>
+        <pre><code id='each'><span class="param"> @include</span> each(<span class="num" contenteditable id="each-every">3</span>,<span class="num" contenteditable id="each-from">0</span>)&#x000A;<span class="comment"> // This mixin uses 2 arguments, the first one is equal to N item,&#x000A; // the second is the starting item and can be omitted, the default value is 0.  </span>&#x000A;&#x000A;<span class="param"> @include</span> every(<span class="num">3</span>, <span class="num">1</span>)&#x000A;<span class="comment"> // Alias of each(), but the starting item defaults to 1.</span>&#x000A;</code></pre>
         <ul class='each'>
           <li>1</li>
           <li>2</li>

--- a/build/javascripts/demo.js
+++ b/build/javascripts/demo.js
@@ -211,20 +211,31 @@ document.getElementById('all-but').addEventListener('keyup', function(){
 // each
 ///////////////////////////////
 
-function each(num) {
-	function injectStyle(num){
+function each(numa, numb) {
+	function injectStyle(numa, numb){
 		document.getElementById('style-each').innerHTML = `ul.each li { ${preStyle} }`;
-		document.getElementById('style-each').innerHTML += `.each li:nth-child(${num}n){
-			${selectedStyle}
+
+		if (numb == 0) {
+  		document.getElementById('style-each').innerHTML += `.each li:nth-child(${numa}n){
+  			${selectedStyle}
+  		}
+  		`
 		}
-		`
+		else {
+  		document.getElementById('style-each').innerHTML += `.each li:nth-child(${numa}n + ${numb}){
+  			${selectedStyle}
+  		}
+  		`
+		}
 	}
 
-	var newStyle = injectStyle(num);
+	var newStyle = injectStyle(numa, numb);
 
 }
 document.getElementById('each').addEventListener('keyup', function(){
-	each(this.innerHTML)
+	var vala = document.getElementById('each-every').innerHTML;
+	var valb = document.getElementById('each-from').innerHTML;
+	each(vala, valb)
 })
 
 ///////////////////////////////

--- a/source/javascripts/demo.js
+++ b/source/javascripts/demo.js
@@ -211,20 +211,31 @@ document.getElementById('all-but').addEventListener('keyup', function(){
 // each
 ///////////////////////////////
 
-function each(num) {
-	function injectStyle(num){
+function each(numa, numb) {
+	function injectStyle(numa, numb){
 		document.getElementById('style-each').innerHTML = `ul.each li { ${preStyle} }`;
-		document.getElementById('style-each').innerHTML += `.each li:nth-child(${num}n){
-			${selectedStyle}
+
+		if (numb == 0) {
+  		document.getElementById('style-each').innerHTML += `.each li:nth-child(${numa}n){
+  			${selectedStyle}
+  		}
+  		`
 		}
-		`
+		else {
+  		document.getElementById('style-each').innerHTML += `.each li:nth-child(${numa}n + ${numb}){
+  			${selectedStyle}
+  		}
+  		`
+		}
 	}
 
-	var newStyle = injectStyle(num);
+	var newStyle = injectStyle(numa, numb);
 
 }
 document.getElementById('each').addEventListener('keyup', function(){
-	each(this.innerHTML)
+	var vala = document.getElementById('each-every').innerHTML;
+	var valb = document.getElementById('each-from').innerHTML;
+	each(vala, valb)
 })
 
 ///////////////////////////////

--- a/source/layouts/partials/_demo.html.haml
+++ b/source/layouts/partials/_demo.html.haml
@@ -157,7 +157,7 @@
             :preserve
               <span class="param">@include</span> n-between(<span class="num" contenteditable id="n-between-a">3</span>,<span class="num" contenteditable id="n-between-b">3</span>,<span class="num" contenteditable id="n-between-c">13</span>)
               <span class="comment"> // This mixin uses 3 arguments, the first one is equal to N item,
-               // the second is the starting item and the thirs the end item.  </span>
+               // the second is the starting item and the third the end item.  </span>
 
         %ul.n-between
           %li 1
@@ -200,9 +200,11 @@
         %header
           %h3 each
         %pre
-          %code
+          %code#each
             :preserve
-              <span class="param"> @include</span> each(<span class="num" contenteditable id="each">3</span>)
+              <span class="param"> @include</span> each(<span class="num" contenteditable id="each-every">3</span>,<span class="num" contenteditable id="each-from">0</span>)
+              <span class="comment"> // This mixin uses 2 arguments, the first one is equal to N item,
+               // the second is the starting item and can be omitted, the default value is 0.  </span>
 
               <span class="comment"> // Alias of each()</span>
               <span class="param"> @include</span> every(<span class="num" contenteditable id="each">3</span>)

--- a/source/layouts/partials/_demo.html.haml
+++ b/source/layouts/partials/_demo.html.haml
@@ -206,8 +206,8 @@
               <span class="comment"> // This mixin uses 2 arguments, the first one is equal to N item,
                // the second is the starting item and can be omitted, the default value is 0.  </span>
 
-              <span class="comment"> // Alias of each()</span>
-              <span class="param"> @include</span> every(<span class="num" contenteditable id="each">3</span>)
+              <span class="param"> @include</span> every(<span class="num">3</span>, <span class="num">1</span>)
+              <span class="comment"> // Alias of each(), but the starting item defaults to 1.</span>
 
         %ul.each
           %li 1

--- a/source/src/_family.scss
+++ b/source/src/_family.scss
@@ -91,30 +91,29 @@
   }
 }
 
-/// Select children each `$num`.
+/// Select children each `$num` with optional `$offset`.
 /// @group with-arguments
 /// @content [Write the style you want to apply to the children, and it will be added within the @content directive]
 /// @param {number} $num - id of the child
+/// @param {number} $offset - starting point
 /// @alias every
-@mixin each($num, $from: 0) {
+@mixin each($num, $offset: 0) {
 
-  @if $from == 0 {
+  @if $offset == 0 {
     &:nth-child(#{$num}n) {
       @content;
     }
   } @else {
-    &:nth-child(#{$num}n + #{$from}) {
+    &:nth-child(#{$num}n + #{$offset}) {
       @content;
     }
   }
 }
 
-/// Select children each `$num`.
-/// @group with-arguments
-/// @content [Write the style you want to apply to the children, and it will be added within the @content directive]
-/// @param {number} $num - id of the child
-@mixin every($num, $from: 1) {
-  @include each($num, $from) {
+/// Alias of each()
+/// $offset - defaults to 1
+@mixin every($num, $offset: 1) {
+  @include each($num, $offset) {
     @content;
   }
 }

--- a/source/src/_family.scss
+++ b/source/src/_family.scss
@@ -98,12 +98,12 @@
 /// @alias every
 @mixin each($num, $from: 0) {
 
-  @if $from != 0 {
-    &:nth-child(#{$num}n + $from) {
+  @if $from == 0 {
+    &:nth-child(#{$num}n) {
       @content;
     }
   } @else {
-    &:nth-child(#{$num}n) {
+    &:nth-child(#{$num}n + #{$from}) {
       @content;
     }
   }
@@ -113,8 +113,8 @@
 /// @group with-arguments
 /// @content [Write the style you want to apply to the children, and it will be added within the @content directive]
 /// @param {number} $num - id of the child
-@mixin every($num) {
-  &:nth-child(#{$num}n) {
+@mixin every($num, $from: 1) {
+  @include each($num, $from) {
     @content;
   }
 }

--- a/source/src/_family.scss
+++ b/source/src/_family.scss
@@ -96,9 +96,16 @@
 /// @content [Write the style you want to apply to the children, and it will be added within the @content directive]
 /// @param {number} $num - id of the child
 /// @alias every
-@mixin each($num) {
-  &:nth-child(#{$num}n) {
-    @content;
+@mixin each($num, $from: 0) {
+
+  @if $from != 0 {
+    &:nth-child(#{$num}n + $from) {
+      @content;
+    }
+  } @else {
+    &:nth-child(#{$num}n) {
+      @content;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #61 #37 #67 

Hi @LukyVj I needed the functionality requested in the previous issues so went ahead and wrote the code.

I'm using the `:nth-child(3n + 1)` method, where 1 indicates the offset.

Also updated the documentation and made `every()` an actual alias of `each()` with a different default starting point. They now use the same logic.

Caveats
- By providing a default 0 we garante we don't break anyones use of the `each()` mixin
- By providing a default of 1 to `every()` it might break the current use so it's your call to keep them different or not.
