### PR TITLE
List gem as alternative install

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Website : [http://lukyvj.github.io/family.scss/](http://lukyvj.github.io/family.
 ### Alternative install
 - `$ npm install family.scss`
 - `$ bower install family.scss`
+- `gem install family-rails` ([maintained by pzi](https://github.com/pzi/family-rails))
 
 Family.scss on [npm](https://www.npmjs.com/package/family.scss)
 


### PR DESCRIPTION
As mentioned in #29, I finally got around to release [**family.scss** as a Rails gem](https://github.com/pzi/family-rails) – my first one 🎉 .

This PR adds the gem as alternative install to the README with a reference to its repository.
