### PR TITLE
Add support for Eyeglass

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ Website : [http://lukyvj.github.io/family.scss/](http://lukyvj.github.io/family.
 Family.scss on [npm](https://www.npmjs.com/package/family.scss)
 
 ## Usage
-First of all, import the [Family.scss source file](https://github.com/LukyVj/family.scss/blob/master/source/src/_family.scss) into your project.
+First of all, you need to import Family.scss into your project. If you're using [eyeglass](http://eyeglass.rocks/) you can import it as such:
+```scss
+@import "family";
+```
+Otherwise import the [Family.scss source file](https://github.com/LukyVj/family.scss/blob/master/source/src/_family.scss).
 
 Then you can use the mixins right away on your stylesheets.
 

--- a/eyeglass-exports.js
+++ b/eyeglass-exports.js
@@ -1,0 +1,7 @@
+var path = require("path");
+
+module.exports = function(eyeglass, sass) {
+  return {
+    sassDir: path.join(__dirname, "source/src")
+  };
+};

--- a/package.json
+++ b/package.json
@@ -22,12 +22,18 @@
     "nth-of-type",
     "nth-of-child",
     "css",
-    "selector"
+    "selector",
+    "eyeglass-module"
   ],
   "author": "Lucas Bonomi <@LukyVj> (http://lucasbonomi.com)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/LukyVj/family.scss/issues"
   },
-  "homepage": "https://github.com/LukyVj/family.scss#readme"
+  "homepage": "https://github.com/LukyVj/family.scss#readme",
+  "eyeglass": {
+    "name": "family",
+    "needs": "*",
+    "exports": "eyeglass-exports.js"
+  }
 }


### PR DESCRIPTION
I'm not sure about the name "family" since the projects' name is "family.scss" but Eyeglass doesn't allow file extensions in names. "family" has the added benefit that it can be imported as `@import "family";` instead of something like `@import "family-scss/family";`.