### PR TITLE
Update all-but() mixin to support all-but(first) and all-but(last)

### DIFF
--- a/source/src/_family.scss
+++ b/source/src/_family.scss
@@ -84,10 +84,20 @@
 /// Select all children but `$num`.
 /// @group with-arguments
 /// @content [Write the style you want to apply to the children, and it will be added within the @content directive]
-/// @param {number} $num - id of the child
+/// @param {number|string} $num - id of the child, or `first` (alias for `1`), or `last`.
 @mixin all-but($num) {
-  &:not(:nth-child(#{$num})) {
-    @content;
+  @if ($num == 1 or $num == first) {
+    &:not(:first-child) {
+      @content;
+    }
+  } @elseif ($num == last) {
+    &:not(:last-child) {
+      @content;
+    }
+  } @else {
+    &:not(:nth-child(#{$num})) {
+      @content;
+    }
   }
 }
 


### PR DESCRIPTION
Hi!

I’d like to bring a small improvement to the `all-but()` mixin, by supporting `first` and `last` as allowed parameters, in addition to integers.

## `first`

`@include all-but(first)` is an alias for `@include all-but(1)`, but it now outputs:

```
&:not(:first-child) { @content; }
```

instead of:

```
&:not(:nth-child(1)) { @content; }
```

## `last`

`@include all-but(last)` is a completely new feature, it outputs:

```
&:not(:last-child) { @content; }
```