### PR TITLE
The domain expired, now being sat on by squatters

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.familyscss.xyz


### PR DESCRIPTION
http://lukyvj.github.io/family.scss

will auto forward to

http://www.familyscss.xyz

Which is just a squatter landing page. Removing the CNAME file will stop the GitHub Pages URL from auto-forwarding to the squatter landing page, allowing people to see the site/documentation again.